### PR TITLE
Fix for projects that use Win32 instead of x86 as the platform

### DIFF
--- a/nuget/UnmanagedExports.nuspec
+++ b/nuget/UnmanagedExports.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata minClientVersion="4.0">
     <id>UnmanagedExports.Repack</id>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <title>Unmanaged Exports (DllExport for .Net) - Adapted for PackageReference</title>
     <authors>Robert Giesecke, repacked by Kevin Gosse</authors>
     <owners>Kevin Gosse</owners>

--- a/nuget/build/UnmanagedExports.Repack.targets
+++ b/nuget/build/UnmanagedExports.Repack.targets
@@ -37,6 +37,7 @@
 			<DllExportAttributeAssemblyNameProp Condition="'$(DllExportAttributeAssemblyNameProp)' == ''">RGiesecke.DllExport.Metadata</DllExportAttributeAssemblyNameProp>
 
 			<DllExportPlatform Condition="'$(DllExportPlatform)' == ''">$(Platform)</DllExportPlatform>
+			<DllExportPlatform Condition="'$(DllExportPlatform)' == 'Win32'">x86</DllExportPlatform>
 			<DllExportPlatformTarget Condition="'$(DllExportPlatformTarget)' == ''">$(PlatformTarget)</DllExportPlatformTarget>
 			<DllExportCpuType Condition="'$(DllExportCpuType)' == ''">$(CpuType)</DllExportCpuType>
 			<DllExportEmitDebugSymbols Condition="'$(DllExportEmitDebugSymbols)' == ''">$(DebugSymbols)</DllExportEmitDebugSymbols>


### PR DESCRIPTION
If the platform is Win32 then RGiesecke.DllExport.Utilities.ToCpuPlatform() fails to parse the string and throw an error.

Set the DllExportPlatform to x86 in the case where Platform is set to Win32(e.g. in projects generated by cmake). Bumped version to 1.0.5